### PR TITLE
Update marina broker according to provider 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ldk": "^0.5.3",
     "lodash.debounce": "^4.0.8",
     "lottie-web": "^5.7.8",
-    "marina-provider": "^1.7.1",
+    "marina-provider": "^1.7.2",
     "moment": "^2.29.1",
     "path-browserify": "^1.0.1",
     "postcss": "^7.0.35",

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -33,7 +33,7 @@ import {
 } from '../../application/redux/actions/wallet';
 import { selectBalances } from '../../application/redux/selectors/balance.selector';
 import { assetGetterFromIAssets } from '../../domain/assets';
-import type { Balance, Template, RawHex, Recipient, Utxo } from 'marina-provider';
+import type { Balance, Template, RawHex, Recipient, Utxo, AddressInterface as ProviderAddressInterface } from 'marina-provider';
 import type { SignTransactionPopupResponse } from '../../presentation/connect/sign-pset';
 import type { SpendPopupResponse } from '../../presentation/connect/spend';
 import type { SignMessagePopupResponse } from '../../presentation/connect/sign-msg';
@@ -55,6 +55,7 @@ import type { UnconfirmedOutput } from '../../domain/unconfirmed';
 import type { Artifact } from '@ionio-lang/ionio';
 import { PrimitiveType } from '@ionio-lang/ionio';
 import type { AnyAction } from 'redux';
+import { isTaprootAddressInterface } from '../../domain/customscript-identity';
 
 export default class MarinaBroker extends Broker<keyof Marina> {
   private static NotSetUpError = new Error('proxy store and/or cache are not set up');
@@ -209,7 +210,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
             identities.map((identity) => identity.getAddresses())
           );
 
-          return successMsg(addresses.flat());
+          return successMsg(addresses.flat().map(toProviderAddress));
         }
 
         case 'getNextAddress': {
@@ -235,7 +236,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
               (action: AnyAction) => this.store?.dispatchAsync(action)
             )
           );
-          return successMsg(nextAddress);
+          return successMsg(toProviderAddress(nextAddress));
         }
 
         case 'getNextChangeAddress': {
@@ -262,7 +263,7 @@ export default class MarinaBroker extends Broker<keyof Marina> {
             )
           );
 
-          return successMsg(nextChangeAddress);
+          return successMsg(toProviderAddress(nextChangeAddress));
         }
 
         case 'signTransaction': {
@@ -546,4 +547,24 @@ function validateTemplate(template: Template): Template<string> | undefined {
       throw new Error(`Unknown template type ${template.type}`);
     }
   }
+}
+
+// converts an addressInterface to the marina-provider format
+function toProviderAddress(addr: AddressInterface): ProviderAddressInterface {
+  const result = {
+    blindingPrivateKey: addr.blindingPrivateKey,
+    confidentialAddress: addr.confidentialAddress,
+    derivationPath: addr.derivationPath,
+    publicKey: addr.publicKey,
+  }
+
+  if (isTaprootAddressInterface(addr)) {
+    return {
+      ...result,
+      constructorParams: addr.constructorParams,
+      descriptor: addr.descriptor,
+    }
+  }
+
+  return result;
 }

--- a/src/content/marina/marinaBroker.ts
+++ b/src/content/marina/marinaBroker.ts
@@ -33,7 +33,14 @@ import {
 } from '../../application/redux/actions/wallet';
 import { selectBalances } from '../../application/redux/selectors/balance.selector';
 import { assetGetterFromIAssets } from '../../domain/assets';
-import type { Balance, Template, RawHex, Recipient, Utxo, AddressInterface as ProviderAddressInterface } from 'marina-provider';
+import type {
+  Balance,
+  Template,
+  RawHex,
+  Recipient,
+  Utxo,
+  AddressInterface as ProviderAddressInterface,
+} from 'marina-provider';
 import type { SignTransactionPopupResponse } from '../../presentation/connect/sign-pset';
 import type { SpendPopupResponse } from '../../presentation/connect/spend';
 import type { SignMessagePopupResponse } from '../../presentation/connect/sign-msg';
@@ -556,14 +563,14 @@ function toProviderAddress(addr: AddressInterface): ProviderAddressInterface {
     confidentialAddress: addr.confidentialAddress,
     derivationPath: addr.derivationPath,
     publicKey: addr.publicKey,
-  }
+  };
 
   if (isTaprootAddressInterface(addr)) {
     return {
       ...result,
       constructorParams: addr.constructorParams,
       descriptor: addr.descriptor,
-    }
+    };
   }
 
   return result;

--- a/src/domain/customscript-identity.ts
+++ b/src/domain/customscript-identity.ts
@@ -398,8 +398,6 @@ export class CustomScriptIdentity
                     bip341.findScriptPath(tree, leafHash)
                   );
 
-                pset.data.inputs[index].tapLeafScript =
-                  pset.data.inputs[index].tapLeafScript?.slice(1); // clear tapLeafScript first (we'll overwrite it)
                 pset.updateInput(index, {
                   tapLeafScript: [
                     {

--- a/src/domain/customscript-identity.ts
+++ b/src/domain/customscript-identity.ts
@@ -20,7 +20,6 @@ import type {
   Restorer,
   NetworkString,
   Mnemonic,
-  TemplateResult,
   ScriptInputsNeeds,
 } from 'ldk';
 import type { BlindingDataLike } from 'liquidjs-lib/src/psbt';
@@ -53,16 +52,24 @@ function makeBaseNodeFromNamespace(m: BIP32Interface, namespace: string): BIP32I
   return m.derivePath(path);
 }
 
+// ExtendedTaprootAddressInterface is not the exported interface of the identity
+// TaprootAddressInterface is the "public" version of address objects
 interface ExtendedTaprootAddressInterface extends AddressInterface {
-  result: TemplateResult;
-  tapscriptNeeds: Record<string, ScriptInputsNeeds>; // scripthex -> needs
   descriptor: string;
-  contract: Contract;
   constructorParams?: Record<string, string | number>;
+  // below are only used internaly
+  contract: Contract;
+  tapscriptNeeds: Record<string, ScriptInputsNeeds>; // scripthex -> needs
 }
 
 export type TaprootAddressInterface = AddressInterface &
-  Omit<ExtendedTaprootAddressInterface, 'result' | 'tapscriptNeeds'>;
+  Omit<ExtendedTaprootAddressInterface, 'contract' | 'tapscriptNeeds'>;
+
+export function isTaprootAddressInterface(
+  address: AddressInterface
+): address is TaprootAddressInterface {
+  return 'descriptor' in address;
+}
 
 function asTaprootAddressInterface(
   extended: ExtendedTaprootAddressInterface
@@ -181,15 +188,9 @@ export class CustomScriptIdentityWatchOnly extends Identity implements IdentityI
 
     const contract = new Contract(artifact, constructorArgs, this.network, ecc);
     const outputScript = contract.scriptPubKey;
-    const result = {
-      scriptPubKey: (): Buffer => outputScript,
-      taprootHashTree: contract.getTaprootTree(),
-      taprootInternalKey: H_POINT.toString('hex'),
-    };
     return {
       ...this.outputScriptToAddressInterface(outputScript.toString('hex')),
       publicKey,
-      result,
       contract,
       derivationPath: namespaceToDerivationPath(this.namespace) + '/' + makePath(isChange, index),
       tapscriptNeeds: analyzeTapscriptTree(contract.getTaprootTree()),
@@ -270,7 +271,8 @@ function withoutUndefined<T>(arr: Array<T | undefined>): Array<T> {
 
 export class CustomScriptIdentity
   extends CustomScriptIdentityWatchOnly
-  implements IdentityInterface {
+  implements IdentityInterface
+{
   readonly masterPrivateKeyNode: Mnemonic['masterPrivateKeyNode'];
   readonly masterBlindingKeyNode: Mnemonic['masterBlindingKeyNode'];
   readonly xpub: string;
@@ -354,15 +356,16 @@ export class CustomScriptIdentity
             if (isKeyPath) {
               if (input.tapKeySig !== undefined) continue; // already signed
 
-              if (!this.hasPrivateKey(cachedAddrInfos.result.taprootInternalKey!)) {
+              // ionio contracts always use H_POINT as internal key
+              const internalPubKey = H_POINT.toString('hex');
+
+              if (!this.hasPrivateKey(internalPubKey)) {
                 throw new Error(
                   'marina fails to sign input (internal key not owned by the account)'
                 );
               }
 
-              const toSignAddress = this.getAddressByPublicKey(
-                cachedAddrInfos.result.taprootInternalKey!
-              );
+              const toSignAddress = this.getAddressByPublicKey(internalPubKey);
               if (toSignAddress && toSignAddress.derivationPath) {
                 const pathToPrivKey = toSignAddress.derivationPath.slice(
                   namespaceToDerivationPath(this.namespace).length + 1
@@ -381,10 +384,6 @@ export class CustomScriptIdentity
               cachedAddrInfos.contract.getTaprootTree();
               // if we use the auto-spendable leaf we need to add the tapLeafScript to the input
               if (leafScript) {
-                if (!cachedAddrInfos.result.taprootInternalKey) {
-                  throw new Error('marina fails to sign input (no taproot internal key)');
-                }
-
                 const tree = cachedAddrInfos.contract.getTaprootTree();
                 const leaf = { scriptHex: leafScript };
                 const leafHash = bip341.tapLeafHash(leaf);
@@ -393,7 +392,7 @@ export class CustomScriptIdentity
                 const taprootSignScriptStack = bip341
                   .BIP341Factory(this.ecclib)
                   .taprootSignScriptStack(
-                    Buffer.from(cachedAddrInfos.result.taprootInternalKey, 'hex'),
+                    H_POINT,
                     { scriptHex: leafScript },
                     tree.hash,
                     bip341.findScriptPath(tree, leafHash)

--- a/test/customscript.spec.ts
+++ b/test/customscript.spec.ts
@@ -73,7 +73,7 @@ describe('CustomScriptIdentity', () => {
     expect(random.contract.template).toBeUndefined();
   });
 
-  test('should be able to instatiate a contract identity and import template as Ionio artifact', async () => {
+  test('should be able to instantiate a contract identity and import template as Ionio artifact', async () => {
     const template = JSON.stringify(synthAssetArtifact);
     const random = makeRandomCustomScriptIdentity(template);
     expect(random.contract.namespace).toBe(TEST_NAMESPACE);
@@ -101,7 +101,7 @@ describe('CustomScriptIdentity', () => {
     expect(addr.constructorParams).toBeDefined();
   });
 
-  test('should be able to instatiate a contract identity, fund the contract and spend those funds', async () => {
+  test('should be able to instantiate a contract identity, fund the contract and spend those funds', async () => {
     const template = JSON.stringify(transferWithCaptchaArtifact);
     const random = makeRandomCustomScriptIdentity(template);
     expect(random.contract.namespace).toBe(TEST_NAMESPACE);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6831,10 +6831,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marina-provider@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.7.1.tgz#0f927f350301df61601f509cc30d16d02cd2fc52"
-  integrity sha512-Tp6mpoS6cLFbK4nyLg4FybWATbIZp05c7hyZrHZKjPsHOTfJOkwCWRugIbilYzKD5rpcYhFjJqtdiwRj316zqw==
+marina-provider@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/marina-provider/-/marina-provider-1.7.2.tgz#6a046587f535e344403bc83988554f43104b1d50"
+  integrity sha512-j6hIN0lXxxicudc4FDKZ1dzAoMQY5oGjxl6tkZ4bCOM7ANPNykbB0IVDF49yVuJgckudnuU/U+pU3+WhI2y7+A==
 
 marky@^1.2.2:
   version "1.2.5"


### PR DESCRIPTION
* "cast" AddressInterface to `marina-provider` address format & install marina-provider 1.7.2

bonus
* remove useless trick deleting the first tapLeafScript on signed input (outdated now with full taproot support)
* remove the `result` member (it comes from former version of the custom script identity using marina-descriptors. Now, using Ionio and the `contract` member, we don't need result anymore)

@altafan @tiero please review